### PR TITLE
Compute MLK Day dynamically from the third Monday of January

### DIFF
--- a/isitmlkday/Pages/Index.cshtml.cs
+++ b/isitmlkday/Pages/Index.cshtml.cs
@@ -16,16 +16,10 @@ namespace isitmlkday.Pages
 
         public void OnGet()
         {
-            var today = DateTime.Now;
-            var mlkDay = new DateTime(today.Year, 1, 18);
-            if (today.Month == 1 && today.Day == 18)
-            {
-                IsMLKDay = "YES";
-            }
-            else
-            {
-                IsMLKDay = "NO";
-            }
+            var today = DateTime.Today;
+            var firstDay = new DateTime(today.Year, 1, 1);
+            var mlkDay = firstDay.AddDays(((int)DayOfWeek.Monday - (int)firstDay.DayOfWeek + 7) % 7 + 14);
+            IsMLKDay = today == mlkDay ? "YES" : "NO";
         }
     }
 }


### PR DESCRIPTION
## Summary
- Determine MLK Day programmatically as the third Monday in January.
- Compare against today's date using `DateTime.Today` to set `IsMLKDay` to "YES" or "NO".

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acd9b913f8833186b095ac2a39e788